### PR TITLE
Set single value for scopes parameter

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/go-querystring/query"
@@ -199,6 +200,8 @@ func (a *Auth) SignInWithProvider(opts ProviderSignInOptions) (*ProviderSignInDe
 	if err != nil {
 		return nil, err
 	}
+
+	params.Set("scopes", strings.Join(opts.Scopes, " "))
 
 	if opts.FlowType == PKCE {
 		p, err := generatePKCEParams()


### PR DESCRIPTION
Currently setting multiple scopes builds a url with a query like `scopes=scope1&scopes=scope2`. For at least the Spotify provider this results in only one of the extra scopes getting picked up.

Now this builds a url with a query like `scopes=scope1+scope2`.