### PR TITLE
Invite with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Unofficial [Supabase](https://supabase.io) client for Go. It is an amalgamation of all the libraries similar to the [official Supabase client](https://supabase.io/docs/reference/javascript/supabase-client).
 
 ## Installation
+
 ```
 go get github.com/nedpals/supabase-go
 ```
@@ -12,8 +13,9 @@ go get github.com/nedpals/supabase-go
 Replace the `<SUPABASE-URL>` and `<SUPABASE-URL>` placeholders with values from `https://supabase.com/dashboard/project/YOUR_PROJECT/settings/api`
 
 ### Authenticate
+
 ```go
-package main 
+package main
 import (
     supa "github.com/nedpals/supabase-go"
     "fmt"
@@ -39,8 +41,9 @@ func main() {
 ```
 
 ### Sign-In
+
 ```go
-package main 
+package main
 import (
     supa "github.com/nedpals/supabase-go"
     "fmt"
@@ -66,8 +69,9 @@ func main() {
 ```
 
 ### Insert
+
 ```go
-package main 
+package main
 import (
     supa "github.com/nedpals/supabase-go"
     "fmt"
@@ -101,8 +105,9 @@ func main() {
 ```
 
 ### Select
+
 ```go
-package main 
+package main
 import (
     supa "github.com/nedpals/supabase-go"
     "fmt"
@@ -124,8 +129,9 @@ func main() {
 ```
 
 ### Update
+
 ```go
-package main 
+package main
 import (
     supa "github.com/nedpals/supabase-go"
     "fmt"
@@ -157,8 +163,9 @@ func main() {
 ```
 
 ### Delete
+
 ```go
-package main 
+package main
 import (
     supa "github.com/nedpals/supabase-go"
     "fmt"
@@ -179,7 +186,41 @@ func main() {
 }
 ```
 
+### Invite user by email
+
+```go
+package main
+import (
+    supa "github.com/nedpals/supabase-go"
+    "fmt"
+    "context"
+)
+
+func main() {
+  supabaseUrl := "<SUPABASE-URL>"
+  supabaseKey := "<SUPABASE-KEY>"
+  supabase := supa.CreateClient(supabaseUrl, supabaseKey)
+
+  ctx := context.Background()
+  user, err := supabase.Auth.InviteUserByEmail(ctx, email)
+  if err != nil {
+    panic(err)
+  }
+
+  // or if you want to setup some metadata
+  data := map[string]interface{}{ "invitedBy": "someone" }
+  redirectTo := "https://your_very_successful_app.com/signup"
+  user, err = supabase.Auth.InviteUserByEmailWithData(ctx, email, data, redirectTo)
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Println(user)
+}
+```
+
 ## Roadmap
+
 - [x] Auth support (1)
 - [x] DB support (2)
 - [ ] Realtime
@@ -192,10 +233,13 @@ func main() {
 I just implemented features which I actually needed for my project for now. If you like to implement these features, feel free to submit a pull request as stated in the [Contributing](#contributing) section below.
 
 ## Design Goals
+
 It tries to mimick as much as possible the official Javascript client library in terms of ease-of-use and in setup process.
 
 # Contributing
+
 ## Submitting a pull request
+
 - Fork it (https://github.com/nedpals/supabase-go/fork)
 - Create your feature branch (git checkout -b my-new-feature)
 - Commit your changes (git commit -am 'Add some feature')
@@ -203,4 +247,5 @@ It tries to mimick as much as possible the official Javascript client library in
 - Create a new Pull Request
 
 # Contributors
+
 - [nedpals](https://github.com/nedpals) - creator and maintainer

--- a/auth.go
+++ b/auth.go
@@ -308,9 +308,18 @@ func (a *Auth) SignOut(ctx context.Context, userToken string) error {
 	return nil
 }
 
-// InviteUserByEmail sends an invite link to the given email. Returns a user.
-func (a *Auth) InviteUserByEmail(ctx context.Context, email string) (*User, error) {
-	reqBody, _ := json.Marshal(map[string]string{"email": email})
+// InviteUserByEmailWithOpts sends an invite link to the given email with metadata. Returns a user.
+func (a *Auth) InviteUserByEmailWithData(ctx context.Context, email string, data map[string]interface{}, redirectTo string) (*User, error) {
+	params := map[string]interface{}{"email": email}
+	if data != nil {
+		params["data"] = data
+	}
+
+	if redirectTo != "" {
+		params["redirectTo"] = redirectTo
+	}
+
+	reqBody, _ := json.Marshal(params)
 	reqURL := fmt.Sprintf("%s/%s/invite", a.client.BaseURL, AuthEndpoint)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer(reqBody))
 	if err != nil {
@@ -325,6 +334,11 @@ func (a *Auth) InviteUserByEmail(ctx context.Context, email string) (*User, erro
 	}
 
 	return &res, nil
+}
+
+// InviteUserByEmail sends an invite link to the given email. Returns a user.
+func (a *Auth) InviteUserByEmail(ctx context.Context, email string) (*User, error) {
+	return a.InviteUserByEmailWithData(ctx, email, nil, "")
 }
 
 // adapted from https://go-review.googlesource.com/c/oauth2/+/463979/9/pkce.go#64


### PR DESCRIPTION
Official libraries support an invitation with `data` and a `redirectTo` ( https://supabase.com/docs/reference/javascript/auth-admin-inviteuserbyemail ).

The PR aims to support it (tested locally) and document the invitation. I didn't augment the existing method to give some backwards compatibility.

I am not quite sure about the name of the method being `InviteUserByEmailWithData`. What do you think?