### PR TITLE
Add VerifyOtp method to Auth package

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -364,3 +364,25 @@ func generatePKCEParams() (*PKCEParams, error) {
 		Verifier:        verifier,
 	}, nil
 }
+
+// verify otp takes in a token hash and verify type, verifies the user and returns the the user if succeeded.
+func (a *Auth) VerifyOtp(ctx context.Context, credentials VerifyOtpCredentials) (*AuthenticatedDetails, error) {
+	reqBody, _ := json.Marshal(credentials)
+	reqURL := fmt.Sprintf("%s/%s/verify", a.client.BaseURL, AuthEndpoint)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	res := AuthenticatedDetails{}
+	errRes := authenticationError{}
+	hasCustomError, err := a.client.sendCustomRequest(req, &res, &errRes)
+	if err != nil {
+		return nil, err
+	} else if hasCustomError {
+		return nil, errors.New(fmt.Sprintf("%s: %s", errRes.Error, errRes.ErrorDescription))
+	}
+
+	return &res, nil
+}


### PR DESCRIPTION
This pull request adds a VerifyOtp method to the Auth package. This method allows verifying OTP credentials. The implementation includes creating a new HTTP request to the verification endpoint and handling the response to return authenticated details or an error. This addition enhances the functionality of the Auth package by enabling OTP verification.