### PR TITLE
Add ResetPasswordForEmailWithRedirectUrl method

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -275,10 +275,15 @@ func (a *Auth) UpdateUser(ctx context.Context, userToken string, updateData map[
 	return &res, nil
 }
 
-// ResetPasswordForEmail sends a password recovery link to the given e-mail address.
-func (a *Auth) ResetPasswordForEmail(ctx context.Context, email string) error {
+// ResetPasswordForEmail sends a password recovery link to the given e-mail address, with a redirect URL
+func (a *Auth) ResetPasswordForEmailWithRedirectUrl(ctx context.Context, email string, redirectTo string) error {
 	reqBody, _ := json.Marshal(map[string]string{"email": email})
 	reqURL := fmt.Sprintf("%s/%s/recover", a.client.BaseURL, AuthEndpoint)
+
+	if redirectTo != "" {
+		reqURL += "?redirect_to=" + redirectTo
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer(reqBody))
 	if err != nil {
 		return err
@@ -289,6 +294,11 @@ func (a *Auth) ResetPasswordForEmail(ctx context.Context, email string) error {
 	}
 
 	return nil
+}
+
+// ResetPasswordForEmail sends a password recovery link to the given e-mail address.
+func (a *Auth) ResetPasswordForEmail(ctx context.Context, email string) error {
+	return a.ResetPasswordForEmailWithRedirectUrl(ctx, email, "")
 }
 
 // SignOut revokes the users token and session.

--- a/auth.go
+++ b/auth.go
@@ -275,7 +275,7 @@ func (a *Auth) UpdateUser(ctx context.Context, userToken string, updateData map[
 	return &res, nil
 }
 
-// ResetPasswordForEmail sends a password recovery link to the given e-mail address, with a redirect URL
+// ResetPasswordForEmailWithRedirectUrl sends a password recovery link to the given e-mail address, with a redirect URL
 func (a *Auth) ResetPasswordForEmailWithRedirectUrl(ctx context.Context, email string, redirectTo string) error {
 	reqBody, _ := json.Marshal(map[string]string{"email": email})
 	reqURL := fmt.Sprintf("%s/%s/recover", a.client.BaseURL, AuthEndpoint)

--- a/supabase.go
+++ b/supabase.go
@@ -96,18 +96,18 @@ func (c *Client) sendCustomRequest(req *http.Request, successValue interface{}, 
 	}
 
 	defer res.Body.Close()
-	statusOK := res.StatusCode >= http.StatusOK && res.StatusCode < 300
+	statusOK := res.StatusCode >= http.StatusOK && res.StatusCode <= 300
 	if !statusOK {
 		if err = json.NewDecoder(res.Body).Decode(&errorValue); err == nil {
-			return true, nil
+			return true, nil // there is a custom error, but we couldn't read it
+		} else {
+			return true, err // there is a custom error, and we read it ok
 		}
-
-		return false, fmt.Errorf("unknown, status code: %d", res.StatusCode)
 	} else if res.StatusCode != http.StatusNoContent {
 		if err = json.NewDecoder(res.Body).Decode(&successValue); err != nil {
-			return false, err
+			return false, err // response status ok, but could not read the body
 		}
 	}
 
-	return false, nil
+	return false, nil // no errors
 }


### PR DESCRIPTION
Enable recovery with explicit redirect_to that may be different from the Site URL.

Similar to the official JS client.

https://github.com/supabase/auth-js/blob/bd91e72824ceb075f6fca7ae25bf9f066e6508d2/src/GoTrueClient.ts#L1667
https://github.com/supabase/auth-js/blob/bd91e72824ceb075f6fca7ae25bf9f066e6508d2/src/lib/fetch.ts#L147
https://github.com/supabase/auth-js/blob/bd91e72824ceb075f6fca7ae25bf9f066e6508d2/src/lib/fetch.ts#L154
https://github.com/supabase/auth-js/blob/bd91e72824ceb075f6fca7ae25bf9f066e6508d2/src/lib/fetch.ts#L165