### PR TITLE
Feat: Added redirectTo parameter for ResetPasswordForEmail

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -276,9 +276,12 @@ func (a *Auth) UpdateUser(ctx context.Context, userToken string, updateData map[
 }
 
 // ResetPasswordForEmail sends a password recovery link to the given e-mail address.
-func (a *Auth) ResetPasswordForEmail(ctx context.Context, email string) error {
+func (a *Auth) ResetPasswordForEmail(ctx context.Context, email string, redirectTo string) error {
 	reqBody, _ := json.Marshal(map[string]string{"email": email})
 	reqURL := fmt.Sprintf("%s/%s/recover", a.client.BaseURL, AuthEndpoint)
+	if len(redirectTo) > 0 {
+		reqURL += fmt.Sprintf("?redirect_to=%s", redirectTo)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer(reqBody))
 	if err != nil {
 		return err


### PR DESCRIPTION
According to supabase documentation:
https://supabase.com/docs/guides/auth/passwords?queryGroups=language&language=js#resetting-a-password

this function have a extra parameter redirectTo, that is missing here, I added it trying to minimize things the best that I could.

If you specify an empty string "" in redirectTo parameter the old behavior before this change will happen.