### PR TITLE
fix(auth): properly marshal VerifyOtpCredentials in VerifyOtp method

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -445,7 +445,10 @@ func MarshalVerifyOtpCredentials(c VerifyOtpCredentials) ([]byte, error) {
 
 // verify otp takes in a token hash and verify type, verifies the user and returns the the user if succeeded.
 func (a *Auth) VerifyOtp(ctx context.Context, credentials VerifyOtpCredentials) (*AuthenticatedDetails, error) {
-	reqBody, _ := json.Marshal(credentials)
+	reqBody, err := MarshalVerifyOtpCredentials(credentials)
+	if err != nil {
+		return nil, err
+	}
 	reqURL := fmt.Sprintf("%s/%s/verify", a.client.BaseURL, AuthEndpoint)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer(reqBody))
 	if err != nil {


### PR DESCRIPTION
  ## Bug Description
  The `VerifyOtp` method was using `json.Marshal` directly on the `VerifyOtpCredentials` interface, which doesn't properly handle the interface and ignores errors. This caused OTP verification to fail because the required "type" field was missing from the JSON payload.

  ## Fix
  - Replace `json.Marshal(credentials)` with `MarshalVerifyOtpCredentials(credentials)`
  - Add proper error handling for the marshaling operation
  - This ensures the "type" field is properly included in the JSON payload sent to the Supabase API